### PR TITLE
[fix]Idea Genre_id validation

### DIFF
--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -2,4 +2,9 @@ class Genre < ApplicationRecord
 
   has_many :ideas,dependent: :destroy
 
+  validates :name, presence: true
+  validates :genre_image, presence: true
+
+  attachment :genre_image
+
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -11,7 +11,7 @@ class Idea < ApplicationRecord
 
   validates :title, presence: true
   validates :caption, presence: true
-  validates :genre_id, presence: true
+  #validates :genre_id, presence: true　belongs_toで必須になっているのでいらないバリテーション(重複してしまう)
   validates :image, presence: true
 
   enum adopted_status: {

--- a/app/views/members/ideas/new.html.erb
+++ b/app/views/members/ideas/new.html.erb
@@ -25,7 +25,7 @@
           <%= f.label :caption,"説明(必須)",class: "mt-3" %><br>
           <%= f.text_area :caption, size: "60x7" %><br>
 
-          <%= f.submit "投稿" %>
+          <%= f.submit "投稿"%>
         <% end %>
       </div>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,5 +6,5 @@ ja:
       idea:
         title: タイトル
         caption: 説明
-        genre_id: ジャンル
+        genre: ジャンル #belongs_toで引っ張て来てるのでそちらに合わせてあげる(ここに書くのはカラムでありアソシエーション名)
         image: 画像


### PR DESCRIPTION
### やったこと
- ideas.genre_idのバリデーションが重複していた
  - belongs_to :genre ですで必須だった
  - validates :genre_id を削除
  - それに伴いja.ymlも修正